### PR TITLE
Disallow nonmart input

### DIFF
--- a/R/homologue_functions.R
+++ b/R/homologue_functions.R
@@ -108,10 +108,6 @@ map_to_homologues_oneway <- function(gene_ids = character(0),
 #'
 #' @inheritParams   map_to_homologues_oneway
 #'
-#' @param        host          The URL for the host-site for the biomart
-#'   database.
-#' @param        mart_name     The name of the biomart database to be used.
-#'
 #' @return       A data.frame with columns ID.sp1 and
 #'   ENSEMBLGENE.sp2.
 #'
@@ -123,13 +119,9 @@ map_to_homologues_oneway <- function(gene_ids = character(0),
 
 map_to_ensembl_homologues_with_biomart <- function(gene_ids = character(0),
                                                    dataset_sp1 = NULL,
-                                                   sp1 = "hsapiens",
                                                    sp2 = "mmusculus",
                                                    idtype_sp1 =
-                                                     "ensembl_gene_id",
-                                                   host = "www.ensembl.org",
-                                                   mart_name =
-                                                     "ENSEMBL_MART_ENSEMBL") {
+                                                     "ensembl_gene_id") {
   results_empty <- data.frame(
     ID.sp1 = character(0),
     ENSEMBLGENE.sp2 = character(0),
@@ -153,30 +145,20 @@ map_to_ensembl_homologues_with_biomart <- function(gene_ids = character(0),
 
   # Checks on dataset_sp1
   # - If it is defined, it must
-  #   a) be a mart; b) have a homologue field for sp2; and c) have a field for
+  #   a) be a Mart; b) have a homologue field for sp2; and c) have a field for
   #   the input idtype_sp1
-  # - If it isn't defined, use the default mart for species 1 (and check it)
 
-  # TODO: remove this:
-  # - since this function is not exported, we can ensure all callers
-  #   pass a valid Mart and so don't need default-mart behaviour
-  #
-  # - then move mart-validity checks into select_and_filter
+  # TODO:
+  # - move mart-validity checks into select_and_filter
 
-  dataset_sp1 <- if (is.null(dataset_sp1) && !is.null(sp1)) {
-    use_default_mart(sp1, host, mart_name)
-  } else {
-    dataset_sp1
+  if (is.null(dataset_sp1)) {
+    stop("Mart should be provided as `dataset_sp1`")
   }
 
-  if (!is.null(dataset_sp1)) {
-    stopifnot(
-      is_valid_mart(dataset_sp1, idtype_sp1) &&
-        is_valid_mart(dataset_sp1, homologue_field)
-    )
-  } else {
-    stop("User should provide a biomart object or name for species1")
-  }
+  stopifnot(
+    is_valid_mart(dataset_sp1, idtype_sp1) &&
+      is_valid_mart(dataset_sp1, homologue_field)
+  )
 
   # If the input ids are non-ensembl, they have to be mapped to ensembl-ids
   #   before use in homology searches

--- a/man/map_to_ensembl_homologues_with_biomart.Rd
+++ b/man/map_to_ensembl_homologues_with_biomart.Rd
@@ -5,9 +5,7 @@
 \title{map_to_ensembl_homologues_with_biomart}
 \usage{
 map_to_ensembl_homologues_with_biomart(gene_ids = character(0),
-  dataset_sp1 = NULL, sp1 = "hsapiens", sp2 = "mmusculus",
-  idtype_sp1 = "ensembl_gene_id", host = "www.ensembl.org",
-  mart_name = "ENSEMBL_MART_ENSEMBL")
+  dataset_sp1 = NULL, sp2 = "mmusculus", idtype_sp1 = "ensembl_gene_id")
 }
 \arguments{
 \item{gene_ids}{A vector of gene identifiers for species `sp1`
@@ -16,20 +14,12 @@ and of type `idtype_sp1`.}
 \item{dataset_sp1}{The `biomaRt` dataset that houses the data for
 species `sp1`.}
 
-\item{sp1}{The name of species 1 (using ensembl prefixes
-like `hsapiens` / `mmusculus`).}
-
 \item{sp2}{The name of species 2 (using ensembl prefixes
 like `hsapiens` / `mmusculus`).}
 
 \item{idtype_sp1}{The type of identifier used for species `sp1`;
 this should match one of the field / column names in the biomaRt dataset
 for species `sp1`.}
-
-\item{host}{The URL for the host-site for the biomart
-database.}
-
-\item{mart_name}{The name of the biomart database to be used.}
 }
 \value{
 A data.frame with columns ID.sp1 and

--- a/tests/testthat/test.homologue_db.R
+++ b/tests/testthat/test.homologue_db.R
@@ -9,51 +9,59 @@ context("Tests for db-connection / validity in homologiser")
 test_that(
   "use_default_mart", {
 
-    #      # Test that a valid Mart object is returned
-    #      expect_true(
-    #        is(use_default_mart(), "Mart"),
-    #        info = "test that a valid mart is returned"
-    #      )
+    # replace with skip_if_offline() when cran/testthat is updated to 2.0.1
+    skip_on_travis()
 
-    #      # Test that a valid Mart object is returned - using named args
-    #      expect_true(
-    #        is(
-    #          use_default_mart(
-    #            sp = "hsapiens",
-    #            host = "www.ensembl.org",
-    #            mart_name = "ENSEMBL_MART_ENSEMBL"
-    #          ),
-    #          "Mart"
-    #        ),
-    #        info = "test that a valid mart is returned"
-    #      )
+    # I wasn't able to meaningfully mock-out these tests
+    # - the whole purpose of this function is to get a Mart object from the
+    # biomart server
 
-    #      # species name, hostname and martname should all be valid in
-    #      # use_default_mart
-    #      expect_error(
-    #        use_default_mart(
-    #          sp = "NOT_A_SPECIES",
-    #          host = "www.ensembl.org",
-    #          mart_name = "ENSEMBL_MART_ENSEMBL"
-    #        ),
-    #        info = "non-standard species name"
-    #      )
-    #      expect_error(
-    #        use_default_mart(
-    #          sp = "hsapiens",
-    #          host = "NOT_A_URL",
-    #          mart_name = "ENSEMBL_MART_ENSEMBL"
-    #        ),
-    #        info = "non-standard host URL"
-    #      )
-    #      expect_error(
-    #        use_default_mart(
-    #          sp = "hsapiens",
-    #          host = "www.ensembl.org",
-    #          mart_name = "NOT_A_MARTNAME"
-    #        ),
-    #        info = "non-standard mart_name"
-    #      )
+    # Test that a valid Mart object is returned
+    expect_is(
+      use_default_mart(),
+      "Mart",
+      info = "test that a valid Mart object is returned"
+    )
+
+    # Test that a valid Mart object is returned - using named args
+    expect_is(
+      use_default_mart(
+        sp = "hsapiens",
+        host = "www.ensembl.org",
+        mart_name = "ENSEMBL_MART_ENSEMBL"
+      ),
+      "Mart",
+      info = "test that a valid mart is returned"
+    )
+
+    # species name, hostname and martname should all be valid in
+    # use_default_mart
+    expect_error(
+      use_default_mart(
+        sp = "NOT_A_SPECIES",
+        host = "www.ensembl.org",
+        mart_name = "ENSEMBL_MART_ENSEMBL"
+      ),
+      info = "non-standard species name"
+    )
+
+    expect_error(
+      use_default_mart(
+        sp = "hsapiens",
+        host = "NOT_A_URL",
+        mart_name = "ENSEMBL_MART_ENSEMBL"
+      ),
+      info = "non-standard host URL"
+    )
+
+    expect_error(
+      use_default_mart(
+        sp = "hsapiens",
+        host = "www.ensembl.org",
+        mart_name = "NOT_A_MARTNAME"
+      ),
+      info = "non-standard mart_name"
+    )
   }
 )
 


### PR DESCRIPTION
Mart objects must be passed into `map_to_ensembl_homologues_with_biomart`
    
The new version of `map_to_ensembl_homologues_with_biomart` must receive a
valid biomaRt::Mart object. This behaviour can be guaranteed since map_to_...
is not an exported function and all package functions that call it can be
written to pass Mart objects in.
    
All code for making a default Mart object was removed from inside map_to_...
    
This change means the arg-list could be reduced: sp1, host and mart_name are
now irrelevant (they were only used while defining the default Mart).
    
The previous function was able to construct a Mart object from host / mart-name
/ species arguments.
    
tests for `map_to_ensembl_with_biomart` were updated
    
Tests were rewritten to pass in a Mart object, rather than relying on map_...
to construct the required Mart object.
    
Since no route to make a default Mart object is available, the sp1, host and
mart_name arguments were removed from `map_...`. Hence, any test that
provided, or tested the validity, of these arguments was rewritten or removed.

Also:

Unit tests were added back into `use_default_mart` because the function no longer had any coverage. But these unit tests depend on internet access and have been set to skip on Travis.CI